### PR TITLE
Add bitrate information to format output

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ youtubedl.getFormats(url, function(err, formats) {
 
 Will print something like
 
-    { itag: 34, filetype: 'flv', resolution: '360x640' }
-    { itag: 18, filetype: 'mp4', resolution: '360x640' }
-    { itag: 43, filetype: 'webm', resolution: '360x640' }
-    { itag: 5, filetype: 'flv', resolution: '240x400' }
-    { itag: 17, filetype: 'mp4', resolution: '144x176' }
+    { itag: 34, code: '34', filetype: 'flv', resolution: '360x640' }
+    { itag: 18, code: '18', filetype: 'mp4', resolution: '360x640', bitrate: '1127k', mediaformat: 'DASH video', fps: 30, filesize: '189.26MiB'}
+    { itag: 43, code: '43', filetype: 'webm', resolution: '360x640' }
+    { itag: 5, code: '5', filetype: 'flv', resolution: '240x400' }
+    { itag: 17, code: '17', filetype: 'mp4', resolution: '144x176', bitrate: '113k', mediaformat: 'DASH video', fps: 30, filesize: '19.62MiB' }
 
 ## Downloading subtitles
 

--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -234,11 +234,17 @@ ytdl.getInfo = function(url, args, options, callback) {
 
 
 var formatsRegex =
-  /^(\d+)\s+([a-z0-9]+)\s+(\d+x\d+|\d+p|audio only|\?x\d+|unknown)/;
+  /^([\w\- ]+?)\s+([a-z0-9]{2,4})\s+(\d+x\d+|\d+p|audio only|\?x\d+|unknown)(.*)$/;
+var optionalSpecsRegex =
+  /\s+([^,]*?)\s+(\d+k)(.*)$/;
+var fpsRegex = 
+  /, (\d+)fps,/;
+var sizeRegex =
+  /, (\d+(?:\.\d{1,2})?[GMK]iB)/;
 
 /**
  * @param {String} url
- * @param {!Array.<String>} args
+ * @param {!Array.<String>} args`
  * @param {Function(!Error, Object)} callback
  */
 ytdl.getFormats = function(url, args, callback) {
@@ -256,12 +262,34 @@ ytdl.getFormats = function(url, args, callback) {
       var result = formatsRegex.exec(line);
       if (/\[info\]/.test(line)) { status = line.split(' ')[4].slice(0, -1); }
       if (result) {
-        formats.push({
+        var optionalResult = optionalSpecsRegex.exec(result[4])
+        var compiledResult = {
           id         : status,
-          itag       : parseInt(result[1], 10),
+          code       : result[1],
           filetype   : result[2],
           resolution : result[3],
-        });
+        }
+        if (/^\d+$/.test(compiledResult.code)) {
+          compiledResult.itag = parseInt(compiledResult.code, 10)
+        }
+        if (optionalResult) {
+          var mediaformat = optionalResult[1]
+          if (mediaformat.length > 0) {
+            compiledResult.mediaformat = mediaformat;
+          }
+          compiledResult.bitrate = optionalResult[2];
+
+          var everythingElse = optionalResult[3];
+          var fpsResult = fpsRegex.exec(everythingElse);
+          if (fpsResult) {
+            compiledResult.fps = parseInt(fpsResult[1]);
+          }
+          var sizeResult = sizeRegex.exec(everythingElse);
+          if (sizeResult) {
+            compiledResult.filesize = sizeResult[1];
+          }
+        }
+        formats.push(compiledResult);
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "request": "~2.37.0"
   },
   "devDependencies": {
-    "vows": "~0.7.0"
+    "vows": "~0.7.0",
+    "assert-diff": "~0.0.4"
   },
   "licenses": [
     {

--- a/test/getFormat.js
+++ b/test/getFormat.js
@@ -1,30 +1,38 @@
-var vows   = require('vows');
-var ytdl   = require('..');
-var assert = require('assert');
-var video  = 'http://www.youtube.com/watch?v=0k2Zzkw_-0I';
+var vows        = require('vows');
+var ytdl        = require('..');
+var assert      = require('assert-diff');
+var youtube     = 'http://www.youtube.com/watch?v=0k2Zzkw_-0I';
+var crunchyroll = 'http://www.crunchyroll.com/fairy-tail/episode-42-celestial-spirit-beast-662713';
 
 
 var expected = {
-  video: [
-    { id: '0k2Zzkw_-0I', itag: 139, filetype: 'm4a', resolution: 'audio only' },
-    { id: '0k2Zzkw_-0I', itag: 140, filetype: 'm4a', resolution: 'audio only' },
-    { id: '0k2Zzkw_-0I', itag: 171, filetype: 'webm', resolution: 'audio only' },
-    { id: '0k2Zzkw_-0I', itag: 141, filetype: 'm4a', resolution: 'audio only' },
-    { id: '0k2Zzkw_-0I', itag: 172, filetype: 'webm', resolution: 'audio only' },
-    { id: '0k2Zzkw_-0I', itag: 278, filetype: 'webm', resolution: '192x144' },
-    { id: '0k2Zzkw_-0I', itag: 160, filetype: 'mp4', resolution: '192x144' },
-    { id: '0k2Zzkw_-0I', itag: 242, filetype: 'webm', resolution: '320x240' },
-    { id: '0k2Zzkw_-0I', itag: 133, filetype: 'mp4', resolution: '320x240' },
-    { id: '0k2Zzkw_-0I', itag: 243, filetype: 'webm', resolution: '480x360' },
-    { id: '0k2Zzkw_-0I', itag: 134, filetype: 'mp4', resolution: '480x360' },
-    { id: '0k2Zzkw_-0I', itag: 244, filetype: 'webm', resolution: '640x480' },
-    { id: '0k2Zzkw_-0I', itag: 135, filetype: 'mp4', resolution: '640x480' },
-    { id: '0k2Zzkw_-0I', itag: 17, filetype: '3gp', resolution: '176x144' },
-    { id: '0k2Zzkw_-0I', itag: 36, filetype: '3gp', resolution: '320x240' },
-    { id: '0k2Zzkw_-0I', itag: 5, filetype: 'flv', resolution: '400x240' },
-    { id: '0k2Zzkw_-0I', itag: 43, filetype: 'webm', resolution: '640x360' },
-    { id: '0k2Zzkw_-0I', itag: 18, filetype: 'mp4', resolution: '640x360'}
+  youtube: [
+		{"id":"0k2Zzkw_-0I","code":"140","filetype":"m4a","resolution":"audio only","itag":140,"mediaformat":"DASH audio","bitrate":"128k","filesize":"4.44MiB"},
+    {"id":"0k2Zzkw_-0I","code":"171","filetype":"webm","resolution":"audio only","itag":171,"mediaformat":"DASH audio","bitrate":"185k","filesize":"5.36MiB"},
+    {"id":"0k2Zzkw_-0I","code":"141","filetype":"m4a","resolution":"audio only","itag":141,"mediaformat":"DASH audio","bitrate":"255k","filesize":"8.90MiB"},
+    {"id":"0k2Zzkw_-0I","code":"278","filetype":"webm","resolution":"192x144","itag":278,"mediaformat":"DASH video","bitrate":"117k","fps":15,"filesize":"2.57MiB"},
+    {"id":"0k2Zzkw_-0I","code":"160","filetype":"mp4","resolution":"192x144","itag":160,"mediaformat":"DASH video","bitrate":"120k","fps":15,"filesize":"3.90MiB"},
+    {"id":"0k2Zzkw_-0I","code":"242","filetype":"webm","resolution":"320x240","itag":242,"mediaformat":"DASH video","bitrate":"207k","fps":30,"filesize":"5.96MiB"},
+    {"id":"0k2Zzkw_-0I","code":"133","filetype":"mp4","resolution":"320x240","itag":133,"mediaformat":"DASH video","bitrate":"248k","fps":30,"filesize":"8.53MiB"},
+    {"id":"0k2Zzkw_-0I","code":"243","filetype":"webm","resolution":"480x360","itag":243,"mediaformat":"DASH video","bitrate":"358k","fps":30,"filesize":"10.21MiB"},
+    {"id":"0k2Zzkw_-0I","code":"134","filetype":"mp4","resolution":"480x360","itag":134,"mediaformat":"DASH video","bitrate":"605k","fps":30,"filesize":"13.12MiB"},
+    {"id":"0k2Zzkw_-0I","code":"244","filetype":"webm","resolution":"640x480","itag":244,"mediaformat":"DASH video","bitrate":"792k","fps":30,"filesize":"20.51MiB"},
+    {"id":"0k2Zzkw_-0I","code":"135","filetype":"mp4","resolution":"640x480","itag":135,"mediaformat":"DASH video","bitrate":"1105k","fps":30,"filesize":"26.55MiB"},
+    {"id":"0k2Zzkw_-0I","code":"17","filetype":"3gp","resolution":"176x144","itag":17},
+    {"id":"0k2Zzkw_-0I","code":"36","filetype":"3gp","resolution":"320x240","itag":36},
+    {"id":"0k2Zzkw_-0I","code":"5","filetype":"flv","resolution":"400x240","itag":5},
+    {"id":"0k2Zzkw_-0I","code":"43","filetype":"webm","resolution":"640x360","itag":43},
+    {"id":"0k2Zzkw_-0I","code":"18","filetype":"mp4","resolution":"640x360","itag":18}
   ],
+
+  crunchyroll: [
+    {"id":"662713","code":"360p","filetype":"flv","resolution":"unknown"},
+    {"id":"662713","code":"480p","filetype":"flv","resolution":"unknown"},
+    {"id":"662713","code":"720p","filetype":"flv","resolution":"unknown"},
+    {"id":"662713","code":"720p","filetype":"flv","resolution":"unknown"},
+    {"id":"662713","code":"1080p","filetype":"flv","resolution":"unknown"},
+    {"id":"662713","code":"1080p","filetype":"flv","resolution":"unknown"}
+   ],
 
   mixcloud: [
     { id: 'TheBloodyBeetroots-sbcr-dj-mix-october-2014', itag: 0, filetype: 'mp3', resolution: 'unknown' }
@@ -32,15 +40,27 @@ var expected = {
 };
 
 vows.describe('getFormats').addBatch({
-  'from a video': {
+  'from a youtube video': {
     'topic': function() {
-      ytdl.getFormats(video, this.callback);
+      ytdl.getFormats(youtube, this.callback);
     },
 
     'formats returned': function(err, formats) {
       assert.isNull(err);
       assert.isArray(formats);
-      assert.deepEqual(formats, expected.video);
+      assert.deepEqual(formats, expected.youtube);
+    }
+  },
+
+  'from a crunchyroll video': {
+    'topic': function() {
+      ytdl.getFormats(crunchyroll, this.callback);
+    },
+
+    'formats returned': function(err, formats) {
+      assert.isNull(err);
+      assert.isArray(formats);
+      assert.deepEqual(formats, expected.crunchyroll);
     }
   },
 


### PR DESCRIPTION
The PR adds a `bitrate` field to the format output when the data is available. An example output would look like this as a result:

```
{ itag: 34, filetype: 'flv', resolution: '360x640' }
{ itag: 18, filetype: 'mp4', resolution: '360x640', bitrate: '1127k' }
{ itag: 43, filetype: 'webm', resolution: '360x640' }
{ itag: 5, filetype: 'flv', resolution: '240x400' }
{ itag: 17, filetype: 'mp4', resolution: '144x176', bitrate: '113k' }
```