### PR TITLE
Feature request: multiple URL support for getInfo()

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,22 @@ Running that will produce something like
     filename: Ace Rimmer to the Rescue-WKsjaOqDXgg.flv
     format id: 34
 
+You can use an array of urls to produce an array of response objects with matching array index (e.g. the 1st response object will match the first url etc...)
+```javascript
+var youtubedl = require('youtube-dl');
+var url1 = 'http://www.youtube.com/watch?v=WKsjaOqDXgg';
+var url2 = 'https://vimeo.com/6586873';
+youtubedl.getInfo([url1, url2], function(err, info) {
+  if (err) throw err;
+
+  console.log('title for the url1:', info[0].title);
+  console.log('title for the url2:', info[1].title);
+});
+```
+
 ## Downloading subtitles
 
-```js
+```javascript
 var youtubedl = require('youtube-dl');
 var url = 'https://youtu.be/PizwcirYuGY';
 
@@ -94,7 +107,7 @@ For more usage info on youtube-dl and the arguments you can pass to it, do `yout
 
 ## Getting the list of extractors
 
-```js
+```javascript
 var youtubedl = require('youtube-dl');
 youtubedl.getExtractors(true, function(err, list) {
   console.log('Found ' + list.length + ' extractors');

--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -85,36 +85,44 @@ ytdl.exec = function (url, args, options, callback) {
  * Calls youtube-dl with some arguments and the `callback`
  * gets called with the output.
  *
- * @param {String} url
+ * @param {String|Array.<String>}
  * @param {Array.<String>} args
  * @param {Array.<String>} args2
  * @param {Object} options
  * @param {Function(!Error, String)} callback
  */
-function call(video, args1, args2, options, callback) {
+function call(urls, args1, args2, options, callback) {
   var args = args1;
   if (args2) {
     args = args.concat(util.parseOpts(args2));
   }
   options = options || {};
 
-  if (isYouTubeRegex.test(video)) {
-    // Get possible IDs.
-    var details = url.parse(video, true);
-    var id = details.query.v || '';
-    if (id) {
-      args.push('http://www.youtube.com/watch?v=' + id);
-    } else {
-      // Get possible IDs for youtu.be from urladdr.
-      id = details.pathname.slice(1).replace(/^v\//, '');
-      if (id || id === 'playlist') {
+  if (urls != null) {
+    if (typeof urls === "string") {
+      urls = [urls]
+    }
+
+    for (var i = 0; i < urls.length; i++) {
+      var video = urls[i];
+      if (isYouTubeRegex.test(video)) {
+        // Get possible IDs.
+        var details = url.parse(video, true);
+        var id = details.query.v || '';
+        if (id) {
+          args.push('http://www.youtube.com/watch?v=' + id);
+        } else {
+          // Get possible IDs for youtu.be from urladdr.
+          id = details.pathname.slice(1).replace(/^v\//, '');
+          if (id || id === 'playlist') {
+            args.push(video);
+          }
+        }
+      } else {
         args.push(video);
       }
     }
-  } else {
-    args.push(video);
   }
-
   var opt = [file, args];
 
   if (isWin) { opt = [process.env.PYTHON || 'python', [file].concat(args)]; }

--- a/test/getInfo.js
+++ b/test/getInfo.js
@@ -86,5 +86,48 @@ vows.describe('getInfo').addBatch({
       assert.equal(info.format, 'h264-sd - 480x272');
       assert.equal(info.duration, '3:55');
     }
+  },
+
+  'from multiple videos': {
+    'topic': function() {
+      var vimeo = 'https://vimeo.com/6586873';
+      var youtube = 'http://www.youtube.com/watch?v=90AiXO1pAiA';
+      ytdl.getInfo([vimeo, youtube], this.callback);
+    },
+
+    'info returned': function(err, info) {
+      assert.isNull(err);
+      assert.isArray(info);
+      assert.equal(info.length, 2);
+      assert.equal(info[0].id, '6586873');
+      assert.equal(info[0].title, 'OWEN - good friends, bad habits');
+      assert.isString(info[0].url);
+      assert.isString(info[0].thumbnail);
+      assert.equal(info[0].description,
+        'Video for the song "Good Friends, Bad Habits" from the album ' +
+        'New Leaves. Directed by Joe Wigdahl. Purchase the album here: ' +
+        'hobbledehoyrecords.com/store');
+      assert.equal(info[0]._filename,
+        'OWEN - good friends, bad habits-6586873.mp4');
+      assert.equal(info[0].format, 'h264-sd - 480x272');
+      assert.equal(info[0].duration, '3:55');
+
+       assert.equal(info[1].id, '90AiXO1pAiA');
+      assert.equal(info[1].format_id, '18');
+      assert.equal(info[1].title, 'lol');
+      assert.isString(info[1].url);
+      assert.isString(info[1].thumbnail);
+      assert.equal(info[1].description,
+        'Ridley High School\'s real American Bad ASS,A true Delco Savage. ' +
+        'Filmed in 2003 before Youtube was invented. ' +
+        'This is also the original I find it hilarious that there ' +
+        'are copycat videos!');
+      assert.equal(info[1]._filename, 'lol-90AiXO1pAiA.mp4');
+      assert.equal(info[1].format, '18 - 640x360');
+      assert.equal(info[1].duration, '12');
+      assert.equal(info[1].width, 640);
+      assert.equal(info[1].height, 360);
+      assert.isArray(info[1].formats);
+    }
   }
 }).export(module);


### PR DESCRIPTION
...such as:

```javascript
var youtubedl = require('youtube-dl');
var url1 = 'http://www.youtube.com/watch?v=WKsjaOqDXgg';
var url2 = 'https://vimeo.com/6586873';
youtubedl.getInfo([url1, url2], function(err, info) {
  if (err) throw err;

  console.log('title for the url1:', info[0].title);
  console.log('title for the url2:', info[1].title);
});
```