### PR TITLE
Fix the broken Host HTTP Header for Dailymotion && Fix Test

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -26,18 +26,18 @@ var subsRegex = /--write-sub|--write-srt|--srt-lang|--all-subs/;
 /**
  * Downloads a video.
  *
- * @param {String} url
+ * @param {String} videoUrl
  * @param {!Array.<String>} args
  * @param {!Object} options
  */
-var ytdl = module.exports = function(url, args, options) {
+var ytdl = module.exports = function(videoUrl, args, options) {
   var stream = streamify({
     superCtor: http.ClientResponse,
     readable: true,
     writable: false
   });
 
-  ytdl.getInfo(url, args, options, function(err, data) {
+  ytdl.getInfo(videoUrl, args, options, function(err, data) {
     if (err) {
       stream.emit('error', err);
       return;
@@ -45,7 +45,13 @@ var ytdl = module.exports = function(url, args, options) {
 
     var item = (!data.length) ? data : data.shift();
 
-    var req = request(item.url);
+    var req = request({
+      url: item.url,
+      headers: {
+        'Host': url.parse(item.url).hostname
+      }
+    });
+    
     req.on('response', function(res) {
       if (res.statusCode !== 200) {
         stream.emit('error', new Error('status code ' + res.statusCode));

--- a/test/getFormat.js
+++ b/test/getFormat.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var youtubevideo = 'http://www.youtube.com/watch?v=0k2Zzkw_-0I';
 var mixcloudvideo =
   'http://www.mixcloud.com/' +
-  'TheBloodyBeetroots/sbcr-dj-mix-october-2014/';
+  'ItchFM/mr-dex-the-dex-files-ep-84/';
 
 vows.describe('getFormats').addBatch({
   'from a video': {


### PR DESCRIPTION
When I try to download a video from Dailymotion, it fails.

That's because the node `request` module sends the requests with a lowercase `host` HTTP Header, whereas it works only with a capitalized `Host` HTTP Header.

Also, one test didn't pass because the MixCloud URL was a 404.