### PR TITLE
Specify download format 'best' if none supplied

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -217,6 +217,10 @@ ytdl.getInfo = function(url, args, options, callback) {
     args = [];
   }
   var defaultArgs = ['--dump-json'];
+  if (!args || args.indexOf('-f') < 0) {
+      defaultArgs.push('-f');
+      defaultArgs.push('best');
+  }
   call(url, defaultArgs, args, options, function(err, data) {
     if (err) return callback(err);
 


### PR DESCRIPTION
When I try to download a video from youtube, node-youtube-dl is crashing
```javascript
url.js:110
    throw new TypeError("Parameter 'url' must be a string, not " + typeof url)
          ^
TypeError: Parameter 'url' must be a string, not undefined
```

`youtube-dl --dump-json $url` for versions after 2015.04.17 do not have a "url" key if a format is not specified, which causes an error on this line https://github.com/fent/node-youtube-dl/blob/master/lib/youtube-dl.js#L51

This change attempts to add `-f best` if none is supplied