### PR TITLE
Add an example of a post download hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ video.on('info', function(info) {
 });
 
 video.pipe(fs.createWriteStream('myvideo.mp4'));
+
+video.on('close', function(){
+  console.log("Download complete")
+})
 ```
 
 


### PR DESCRIPTION
The README doesn't specify how to run code after the download has completed, so I've added an example. This is especially helpful when downloading videos in series.