### PR TITLE
add try-catch for downloader

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -45,7 +45,13 @@ function addToPkg() {
   list.splice(list.indexOf('main') + 1, 0, 'bin');
   pkg.bin = filePath;
   pkg = sortObj(pkg, list);
-  fs.writeFileSync(path.join(__dirname, '..', 'package.json'), JSON.stringify(pkg, null, 2), 'utf8');
+
+  try {
+    fs.writeFileSync(path.join(__dirname, '..', 'package.json'), JSON.stringify(pkg, null, 2), 'utf8');
+  }
+  catch(error) {
+    console.log(error);
+  }
 }
 
 function downloader(binDir, callback) {


### PR DESCRIPTION
This can be problematic if we don't use try-catch in some special scenarios. 